### PR TITLE
jh7100: fix hang during os boot by not to choose hart0

### DIFF
--- a/lib/sbi/sbi_platform.c
+++ b/lib/sbi/sbi_platform.c
@@ -80,8 +80,13 @@ u32 sbi_platform_hart_index(const struct sbi_platform *plat, u32 hartid)
 		return -1U;
 	if (plat->hart_index2id) {
 		for (i = 0; i < plat->hart_count; i++) {
-			if (plat->hart_index2id[i] == hartid)
+			sbi_printf("sbi_platform_hart_index: i=%d hart_index2id=%d\n",
+					i, plat->hart_index2id[i]);
+			if (plat->hart_index2id[i] == hartid) {
+				sbi_printf("sbi_platform_hart_index: matched=%d\n",
+					hartid);
 				return i;
+			}
 		}
 		return -1U;
 	}

--- a/platform/starfive/vic7100/platform.c
+++ b/platform/starfive/vic7100/platform.c
@@ -23,7 +23,7 @@
 
 /* clang-format off */
 
-#define VIC7100_HART_COUNT					2
+#define VIC7100_HART_COUNT					3
 
 #define VIC7100_SYS_CLK						1000000000
 
@@ -210,6 +210,11 @@ static int vic7100_vendor_ext_provider(long extid, long funcid,
 	return ret;
 }
 
+static u32 vic7100_hart_index2id[VIC7100_HART_COUNT - 1] = {
+        [0] = 1,
+        [1] = 2,
+};
+
 const struct sbi_platform_operations platform_ops = {
 	.final_init		= vic7100_final_init,
 	.console_putc		= uart8250_putc,
@@ -234,7 +239,8 @@ const struct sbi_platform platform = {
 	.platform_version	= SBI_PLATFORM_VERSION(0x0, 0x01),
 	.name			= "StarFive VIC7100",
 	.features		= SBI_PLATFORM_DEFAULT_FEATURES,
-	.hart_count		= (VIC7100_HART_COUNT),
+	.hart_count		= (VIC7100_HART_COUNT - 1),
+	.hart_index2id          = vic7100_hart_index2id,
 	.hart_stack_size	= SBI_PLATFORM_DEFAULT_HART_STACK_SIZE,
 	.platform_ops_addr	= (unsigned long)&platform_ops
 };


### PR DESCRIPTION
The jh7100 SoC have e24(rv32) in hart0 and u73(rv64) in
hart1 and hart2. Prevent opensbi to choose hart0 for the
booting core for the os since e24 is not compatible with u73.

Signed-off-by: Akira Tsukamoto <akira.tsukamoto@gmail.com>